### PR TITLE
proxy pass to the console on 404

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,12 +47,18 @@ http {
         include /etc/nginx/default.d/*.conf;
 
         location / {
+                index index.html
+                try_files $uri $uri/ @conbackend;
         }
 
-        # This is added to support pushState URL patterm
-        # Redirecting every 404 to angular APP and 
-        # let the APP handle
-        error_page 404 =200 /index.html;
+        location @conbackend {
+            proxy_pass http://f8ui;
+            proxy_redirect off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        error_page 404 = @conbackend;
 
         error_page 500 502 503 504 /50x.html;
             location = /50x.html {


### PR DESCRIPTION
any content not on the local service instance, should be passed along to the f8ui/ service. 

This is going to be a perf hit when we start scaling, and I've made a note to revisit once we can measure things to see if we can do this better, down the road.