### PR TITLE
need to use port 8080

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -52,7 +52,7 @@ http {
         }
 
         location @conbackend {
-            proxy_pass http://f8ui;
+            proxy_pass http://f8ui:8080;
             proxy_redirect off;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
the internal service runs on port 8080, we need to use that to use the service backend instead of the :80 default.