### PR TITLE
restore the nginx.conf so we can bring back offload proxy to f8ui

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -2,6 +2,7 @@ FROM registry.centos.org/fabric8/openshift-nginx:latest
 MAINTAINER "Pete Muir <pmuir@bleepbleep.org.uk>"
 
 USER root
+ADD nginx.conf /etc/nginx/nginx.conf
 
 RUN rm -rf /usr/share/nginx/html/
 COPY dist /usr/share/nginx/html

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,78 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+
+worker_processes 1;
+error_log /dev/stdout info;
+pid /run/nginx.pid;
+daemon off;
+
+# Load dynamic modules. See /usr/share/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log 		/dev/stdout main;
+    client_body_temp_path /tmp;
+    fastcgi_temp_path /tmp;
+    scgi_temp_path /tmp;
+    proxy_temp_path /tmp;
+    uwsgi_temp_path /tmp;
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        location / {
+                index index.html
+                try_files $uri $uri/ @conbackend;
+        }
+
+        location @conbackend {
+            proxy_pass http://f8ui:8080;
+            proxy_redirect off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        error_page 404 = @conbackend;
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+
+        gzip            on;
+        gzip_min_length 1000;
+        gzip_comp_level 9;
+        gzip_proxied    expired no-cache no-store private auth;
+        gzip_types      text/plain text/css application/javascript application/xml;
+    }
+
+# Settings for a TLS enabled server.
+# - we dont do TLS here, offload that to the openshift edge instead
+
+}
+


### PR DESCRIPTION
we seem to have lost the ability to proxy back to the console and services. this PR should bring that back ( but we might lose CORS, which we can address in the next PR )